### PR TITLE
Convert spaces in path to %20.

### DIFF
--- a/lua/web-tools/browsersync.lua
+++ b/lua/web-tools/browsersync.lua
@@ -66,6 +66,7 @@ M.open = function(args)
   local path = '/'
   if (args[1] and type(args[1]) == 'string') and (args[1] == '/' or vim.fn.filereadable(args[1])) == 1 then
     path = args[1]
+	path = path:gsub(' ', '%%20')
   end
   if not M.running() then
     vim.notify('server not started', vim.log.levels.ERROR)


### PR DESCRIPTION
If the filepath has spaces, BrowserPreview is unable to open the file.

The fix was to replace the spaces in the path with %20 ([Percent-encoding](https://en.wikipedia.org/wiki/Percent-encoding)).  
This is only done if a valid filepath is detected.